### PR TITLE
New version 2.0 updated to work on `api.json` from 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,130 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+

--- a/generator.py
+++ b/generator.py
@@ -104,29 +104,29 @@ def generate_method_definition(func):
             "is_required"] else " (Optional)\n"
 
         method_definition += " " * indent
-
-    open_index = func["returns"].find('(')
-    close_index = func["returns"].find(
-        ')', (open_index if open_index > -1 else 0))
-
-    func["returns"] = func["returns"].replace("\t", " " * 4)
-    return_string = func["returns"].replace("\n", "")
-
-    if open_index < close_index and func["returns"][
-                                    open_index + 1:close_index] in DTYPE_MAPPING:
-        method_definition += ":rtype: " + DTYPE_MAPPING[
-            func["returns"][open_index + 1:close_index]]
-
-        func["returns"] = func["returns"].replace(
-            func["returns"][open_index:close_index + 1], "")
-
-        method_definition += "\n" + " " * indent
-
-    method_definition += ":return: " + return_string
-
-    for i in range(0, len(return_string) + 1, 80 - (indent + 2)):
-        method_definition += return_string[i:i + (
-                80 - (indent + 2))] + "\n" + " " * indent
+    # Do not parse the returns because it doesn't work correctly at the moment
+#    open_index = func["returns"].find('(')
+#    close_index = func["returns"].find(
+#        ')', (open_index if open_index > -1 else 0))
+#
+#    func["returns"] = func["returns"].replace("\t", " " * 4)
+#    return_string = func["returns"].replace("\n", "")
+#
+#    if open_index < close_index and func["returns"][
+#                                    open_index + 1:close_index] in DTYPE_MAPPING:
+#        method_definition += ":rtype: " + DTYPE_MAPPING[
+#            func["returns"][open_index + 1:close_index]]
+#
+#        func["returns"] = func["returns"].replace(
+#            func["returns"][open_index:close_index + 1], "")
+#
+#        method_definition += "\n" + " " * indent
+#
+#    method_definition += ":return: " + return_string
+#
+#    for i in range(0, len(return_string) + 1, 80 - (indent + 2)):
+#        method_definition += return_string[i:i + (
+#                80 - (indent + 2))] + "\n" + " " * indent
 
     # Close it off & reindent
     method_definition += '"""' + "\n" + " " * indent

--- a/generator.py
+++ b/generator.py
@@ -173,7 +173,7 @@ def generate_lbryd_wrapper(url=LBRY_API_RAW_JSON_URL, read_file=__LBRYD_BASE_FPA
     :param str write_file: Path from project root to the file we'll be writing to.
      """
 
-    functions = get_lbry_api_function_docs(url)
+    sections = get_lbry_api_function_docs(url)
 
     # Open the actual file for appending
     with open(write_file, 'w') as lbry_file:
@@ -187,12 +187,14 @@ def generate_lbryd_wrapper(url=LBRY_API_RAW_JSON_URL, read_file=__LBRYD_BASE_FPA
         lbry_file.write(header)
 
         # Iterate through all the functions we retrieved
-        for func in functions:
+        for section in sections:
+            commands = sections[section]["commands"]
 
-            method_definition = generate_method_definition(func)
+            for command in commands:
+                method_definition = generate_method_definition(command)
 
-            # Write to file
-            lbry_file.write(method_definition)
+                # Write to file
+                lbry_file.write(method_definition)
 
     try:
         from yapf.yapflib.yapf_api import FormatFile

--- a/generator.py
+++ b/generator.py
@@ -1,3 +1,4 @@
+import ast
 from urllib.request import urlopen
 from urllib.error import URLError
 from json import loads
@@ -196,12 +197,30 @@ def generate_lbryd_wrapper(url=LBRY_API_RAW_JSON_URL, read_file=__LBRYD_BASE_FPA
                 # Write to file
                 lbry_file.write(method_definition)
 
+    print("Generated file:", write_file)
+    with open(write_file) as lbry_file:
+        source = lbry_file.read()
+
+    parsed = True
     try:
-        from yapf.yapflib.yapf_api import FormatFile
+        result = ast.parse(source, filename=write_file)
+    except SyntaxError as err:
+        print("The resulting file has syntax errors. Look at the error line for clues.")
+        print("Error:", err)
+        print()
+        print("The problem is usually in the input JSON file; it may contain badly formatted fields.")
+        print("Input:", url)
+        print()
+        parsed = False
 
-        # Now we should format the file using the yapf formatter
-        FormatFile(write_file, in_place=True)
+    if parsed:
+        try:
+            from yapf.yapflib.yapf_api import FormatFile
 
-    except ImportError as IE:
-        print("[Warning]: yapf is not installed, so the generated code will not follow an easy-to-read standard")
-        print(IE)
+            # Now we should format the file using the yapf formatter
+            FormatFile(write_file, in_place=True)
+
+        except ImportError:
+            print()
+            print("[Warning]: 'yapf' could not be imported, so the generated code will not be formatted")
+

--- a/pybry/__init__.py
+++ b/pybry/__init__.py
@@ -3,4 +3,5 @@ from .lbrycrd_api import LbrycrdApi
 from .LBRYException import LBRYException
 
 
-__version__ = '1.6.4'
+__version__ = '2.0.0'
+

--- a/pybry/constants.py
+++ b/pybry/constants.py
@@ -11,7 +11,11 @@ DTYPE_MAPPING = {'list': "list",
                  'bool': "bool",
                  'int': "int",
                  'dict': "dict",
-                 'str': "str"}
+                 'str': "str",
+                 'string': "str",
+                 'str, list': "list",
+                 'str or list': "list",
+                 'date': "str"}
 
 # LBRYCRD documentation doesn't exist at least that I could find
 # LBRYCRD_API_RAW_JSON_URL = ""

--- a/pybry/lbryd_api.py
+++ b/pybry/lbryd_api.py
@@ -2,7 +2,7 @@ from pybry.base_api import BaseApi
 from pybry.constants import LBRYD_SERVER_ADDRESS as SERVER_ADDRESS
 
 
-class LbryApi(BaseApi):
+class LbrydApi(BaseApi):
 
     def __init__(self, timeout=600):
         """


### PR DESCRIPTION
The last version 1.6.4 was released on October 2018. Then it became broken because the format of the `api.json` changed. This pull request fixes the `generator.py` module to be able to parse the JSON that exists now (2021).

* A `.gitignore` file is added to ignore the common temporary files like `pycache/`, `build/`, `.pyc`, etc.
* Fixed the name `pybry.lbryd_api.py.LbrydApi`; it was misspelled, and it made the entire process fail when `pybry` was imported.
* Updated `generator.py`; the `api.json` now has the commands contained in different sections instead of a single list.
* The `pybry.constants.DTYPE_MAPPING` dictionary is augmented with more types that are now included in the `api.json`.
* Inside `generator.py`, the `'returns'` key is ignored as the current `api.json` file does not maintain a proper standard for showing the return value. This will have to be standardized in `lbry.extras.daemon.daemon.Daemon`, so that the `api.json` is properly generated.
* Use `ast.parse` to parse the generated wrapper `pybry/lbryd_api.py` and verify that it has no syntax errors. If it has, the `yapf` formatting will not work, so it is skipped.